### PR TITLE
Handle and upgrade multiple Python Interpreters versions: 3.9, 3.10, 3.11 and 3.12

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@main
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3

--- a/.github/workflows/main-updated.yaml
+++ b/.github/workflows/main-updated.yaml
@@ -1,53 +1,54 @@
+---
 name: main branch updated
 
 on:
-  push:
-    branches:
-      - main
+    push:
+        branches:
+            - main
 
 jobs:
-  bump-version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
-    runs-on: ubuntu-latest
-    name: "Bump version and create changelog with commitizen"
-    steps:
-      - name: Check out
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
-      - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
-        with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          branch: main
+    bump-version:
+        if: "!startsWith(github.event.head_commit.message, 'bump:')"
+        runs-on: ubuntu-latest
+        name: Bump version and create changelog with commitizen
+        steps:
+            - name: Check out
+              uses: actions/checkout@main
+              with:
+                  token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                  fetch-depth: 0
+            - name: Create bump and changelog
+              uses: commitizen-tools/commitizen-action@master
+              with:
+                  github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                  branch: main
 
-  publish-github-page:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@main
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
+    publish-github-page:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out
+              uses: actions/checkout@main
+              with:
+                  token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                  fetch-depth: 0
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@main
-        with:
-          python-version: 3.9
+            - name: Set up Python 3.9
+              uses: actions/setup-python@main
+              with:
+                  python-version: 3.9
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip poetry invoke
-          inv env.init-dev --no-pre-commit
+            - name: Install dependencies
+              run: |
+                  python -m pip install -U pip poetry invoke
+                  inv env.init-dev --no-pre-commit
 
-      - name: Build docs
-        run: |
-          inv doc.build
+            - name: Build docs
+              run: |
+                  inv doc.build
 
-      - name: Push documentation to Github Page
-        uses: peaceiris/actions-gh-pages@v3.8.0
-        with:
-          personal_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./site
+            - name: Push documentation to Github Page
+              uses: peaceiris/actions-gh-pages@v3.8.0
+              with:
+                  personal_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+                  publish_branch: gh-pages
+                  publish_dir: ./site

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -15,8 +15,8 @@ jobs:
         strategy:
             max-parallel: 12
             matrix:
-                platform: [ ubuntu-latest, windows-latest, macos-latest ]
-                python-version: [ 3.9, 3.10, 3.11, 3.12 ]
+                platform: [ubuntu-latest, windows-latest, macos-latest]
+                python-version: [3.9, 3.10, 3.11, 3.12]
         steps:
             - name: Check out
               uses: actions/checkout@main

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             max-parallel: 12
             matrix:
-                platform: [ubuntu-latest, windows-latest]
+                platform: [ubuntu-latest, windows-latest, macos-latest]
                 python-version: [3.9, '3.10', '3.11', '3.12']
         steps:
             - name: Check out

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             max-parallel: 12
             matrix:
-                platform: [ubuntu-latest]
+                platform: [ubuntu-latest, windows-latest]
                 python-version: [3.9, '3.10', '3.11', '3.12']
         steps:
             - name: Check out
@@ -32,6 +32,9 @@ jobs:
               run: |
                   python -m pip install -U pip poetry invoke
                   inv env.init-dev --no-pre-commit
+
+            - name: Setup FFmpeg
+              uses: AnimMouse/setup-ffmpeg@v1
 
             - name: Style check
               run: |

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -24,7 +24,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@main
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -11,17 +11,22 @@ on:
 
 jobs:
     check:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.platform }}
+        strategy:
+            max-parallel: 12
+            matrix:
+                platform: [ ubuntu-latest, windows-latest, macos-latest ]
+                python-version: [ 3.9, 3.10, 3.11, 3.12 ]
         steps:
             - name: Check out
               uses: actions/checkout@main
               with:
                   fetch-depth: 0
 
-            - name: Set up Python 3.9
-              uses: actions/setup-python@main
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
               with:
-                  python-version: 3.9
+              python-version: ${{ matrix.python-version }}
 
             - name: Install dependencies
               run: |
@@ -42,9 +47,13 @@ jobs:
                   poetry run coverage lcov -o ./coverage/lcov.info
 
             - name: Coveralls
+              # Error: Container action is only supported on Linux
+              # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif
+              if: ${{ matrix.platform == 'ubuntu-latest' }}
               uses: coverallsapp/github-action@master
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  parallel: true
 
     coveralls_finish:
         needs: check

--- a/.github/workflows/python-check.yaml
+++ b/.github/workflows/python-check.yaml
@@ -15,8 +15,8 @@ jobs:
         strategy:
             max-parallel: 12
             matrix:
-                platform: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: [3.9, 3.10, 3.11, 3.12]
+                platform: [ubuntu-latest]
+                python-version: [3.9, '3.10', '3.11', '3.12']
         steps:
             - name: Check out
               uses: actions/checkout@main
@@ -26,7 +26,7 @@ jobs:
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v2
               with:
-              python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.python-version }}
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -10,7 +10,7 @@ jobs:
     publish-pypi-package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@main
 
             - name: Set up Python
               uses: actions/setup-python@main

--- a/poetry.lock
+++ b/poetry.lock
@@ -278,6 +278,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -297,6 +308,17 @@ python-versions = ">=3.8"
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]
@@ -1238,13 +1260,13 @@ pytz = "*"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.33"
+version = "9.5.34"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.33-py3-none-any.whl", hash = "sha256:dbc79cf0fdc6e2c366aa987de8b0c9d4e2bb9f156e7466786ba2fd0f9bf7ffca"},
-    {file = "mkdocs_material-9.5.33.tar.gz", hash = "sha256:d23a8b5e3243c9b2f29cdfe83051104a8024b767312dc8fde05ebe91ad55d89d"},
+    {file = "mkdocs_material-9.5.34-py3-none-any.whl", hash = "sha256:54caa8be708de2b75167fd4d3b9f3d949579294f49cb242515d4653dbee9227e"},
+    {file = "mkdocs_material-9.5.34.tar.gz", hash = "sha256:1e60ddf716cfb5679dfd65900b8a25d277064ed82d9a53cd5190e3f894df7840"},
 ]
 
 [package.dependencies]
@@ -1677,13 +1699,13 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "3.2.6"
+version = "3.2.7"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-3.2.6-py3-none-any.whl", hash = "sha256:03c8e3baa1d9fb995b12c1dbe00aa6c4bcef210c2a2634374aedeb22fb4a8f8f"},
-    {file = "pylint-3.2.6.tar.gz", hash = "sha256:a5d01678349454806cff6d886fb072294f56a58c4761278c97fb557d708e1eb3"},
+    {file = "pylint-3.2.7-py3-none-any.whl", hash = "sha256:02f4aedeac91be69fb3b4bea997ce580a4ac68ce58b89eaefeaf06749df73f4b"},
+    {file = "pylint-3.2.7.tar.gz", hash = "sha256:1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e"},
 ]
 
 [package.dependencies]
@@ -1722,6 +1744,25 @@ pyyaml = "*"
 
 [package.extras]
 extra = ["pygments (>=2.12)"]
+
+[[package]]
+name = "pyproject-api"
+version = "1.7.1"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyproject_api-1.7.1-py3-none-any.whl", hash = "sha256:2dc1654062c2b27733d8fd4cdda672b22fe8741ef1dde8e3a998a9547b071eeb"},
+    {file = "pyproject_api-1.7.1.tar.gz", hash = "sha256:7ebc6cd10710f89f4cf2a2731710a98abce37ebff19427116ff2174c9236a827"},
+]
+
+[package.dependencies]
+packaging = ">=24.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2024.5.6)", "sphinx-autodoc-typehints (>=2.2.1)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.2.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=70.1)"]
 
 [[package]]
 name = "pytest"
@@ -2374,6 +2415,33 @@ files = [
 ]
 
 [[package]]
+name = "tox"
+version = "4.18.0"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tox-4.18.0-py3-none-any.whl", hash = "sha256:0a457400cf70615dc0627eb70d293e80cd95d8ce174bb40ac011011f0c03a249"},
+    {file = "tox-4.18.0.tar.gz", hash = "sha256:5dfa1cab9f146becd6e351333a82f9e0ade374451630ba65ee54584624c27b58"},
+]
+
+[package.dependencies]
+cachetools = ">=5.4"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.15.4"
+packaging = ">=24.1"
+platformdirs = ">=4.2.2"
+pluggy = ">=1.5"
+pyproject-api = ">=1.7.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.26.3"
+
+[package.extras]
+docs = ["furo (>=2024.7.18)", "sphinx (>=7.4.7)", "sphinx-argparse-cli (>=1.16)", "sphinx-autodoc-typehints (>=2.2.3)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2023.4.21)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.11)"]
+testing = ["build[virtualenv] (>=1.2.1)", "covdefaults (>=2.3)", "detect-test-pollution (>=1.2)", "devpi-process (>=1)", "diff-cover (>=9.1.1)", "distlib (>=0.3.8)", "flaky (>=3.8.1)", "hatch-vcs (>=0.4)", "hatchling (>=1.25)", "psutil (>=6)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-xdist (>=3.6.1)", "re-assert (>=1.1)", "setuptools (>=70.3)", "time-machine (>=2.14.2)", "wheel (>=0.43)"]
+
+[[package]]
 name = "typeguard"
 version = "4.3.0"
 description = "Run-time type checker for Python"
@@ -2394,13 +2462,13 @@ test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
 
 [[package]]
 name = "types-setuptools"
-version = "74.0.0.20240830"
+version = "74.0.0.20240831"
 description = "Typing stubs for setuptools"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-setuptools-74.0.0.20240830.tar.gz", hash = "sha256:2019cb0ef0fc11c3550946057e1fe78cb934284b856cec5f4ab45b43d9288685"},
-    {file = "types_setuptools-74.0.0.20240830-py3-none-any.whl", hash = "sha256:3ccb05f218012b6d1643f15c3395fced6a290a32bc49338b0e93ece73585a5a2"},
+    {file = "types-setuptools-74.0.0.20240831.tar.gz", hash = "sha256:8b4a544cc91d42a019dc1e41fd397608b4bc7e20c7d7d5bc326589ffd9e8f8a1"},
+    {file = "types_setuptools-74.0.0.20240831-py3-none-any.whl", hash = "sha256:4d9d18ea9214828d695a384633130009f5dee2681a157ee873d3680b62931590"},
 ]
 
 [[package]]
@@ -2540,4 +2608,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a32b95bda6c98b9aff3d64e0b4e82e8df305389dbefb340cb446443f6e47dd6c"
+content-hash = "4686db61907535ccc5054ec852f21bee4cb30ea75a9eadf116a927dd886bd501"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,11 +178,13 @@ mkdocs-git-revision-date-localized-plugin = "^1.0.1"
 mkdocs-minify-plugin = "^0.8.0"
 mkdocs-video = "^1.3.0"
 #mkdocs-click = "^0.7.0"
+# tox
+tox = "^4.8.0"
 
 [tool.poetry.scripts]
 export_imghash_from_media = "vhcalc.app:export_imghash_from_media"
 vhcalc = "vhcalc.app:cli"
 
 [build-system]
-requires = ["poetry>=1.0.0", "setuptools"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.0", "poetry-core>=1.0.0", "setuptools"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -359,9 +359,9 @@ setuptools==74.0.0 ; python_version >= "3.9" and python_version < "4.0" \
 typeguard==4.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:4d24c5b39a117f8a895b9da7a9b3114f04eb63bade45a4492de49b175b6f7dfa \
     --hash=sha256:92ee6a0aec9135181eae6067ebd617fd9de8d75d714fb548728a4933b1dea651
-types-setuptools==74.0.0.20240830 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:2019cb0ef0fc11c3550946057e1fe78cb934284b856cec5f4ab45b43d9288685 \
-    --hash=sha256:3ccb05f218012b6d1643f15c3395fced6a290a32bc49338b0e93ece73585a5a2
+types-setuptools==74.0.0.20240831 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:4d9d18ea9214828d695a384633130009f5dee2681a157ee873d3680b62931590 \
+    --hash=sha256:8b4a544cc91d42a019dc1e41fd397608b4bc7e20c7d7d5bc326589ffd9e8f8a1
 typing-extensions==4.12.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,6 @@ exclude =
     .git,
     __pycache__,
     build,
-    dist
+    dist,
+    .tox
 max-line-length = 88

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -1,3 +1,9 @@
+import sys
+
 VENV_PREFIX = "poetry run"
 _COMMON_TARGETS = ["vhcalc", "tests"]
 COMMON_TARGETS_AS_STR = " ".join(_COMMON_TARGETS)
+
+# - [Add pty support for Windows? #561](https://github.com/pyinvoke/invoke/issues/561)
+# - [invoke fails on windows #62](https://github.com/City-Bureau/city-scrapers/issues/62)
+USE_PTY = sys.platform != "win32"

--- a/tasks/env.py
+++ b/tasks/env.py
@@ -12,7 +12,7 @@ def clean(ctx):
 @task
 def init(ctx):
     """Install production dependencies"""
-    ctx.run("poetry install --no-dev")
+    ctx.run("poetry install --only main")
 
 
 @task

--- a/tasks/git.py
+++ b/tasks/git.py
@@ -1,12 +1,12 @@
 from invoke import task
 
-from tasks.common import VENV_PREFIX
+from tasks.common import USE_PTY, VENV_PREFIX
 
 
 @task
 def commit(ctx):
     """Commit through commitizen"""
-    ctx.run(f"{VENV_PREFIX} cz commit", pty=True)
+    ctx.run(f"{VENV_PREFIX} cz commit", pty=USE_PTY)
 
 
 @task

--- a/tasks/secure.py
+++ b/tasks/secure.py
@@ -1,6 +1,6 @@
 from invoke import task
 
-from tasks.common import VENV_PREFIX
+from tasks.common import USE_PTY, VENV_PREFIX
 
 
 @task
@@ -12,7 +12,7 @@ def check_package(ctx):
 @task
 def bandit(ctx):
     """Check common software vulnerabilities (Use it as reference only)"""
-    ctx.run(f"{VENV_PREFIX} bandit -r -iii -lll --ini .bandit", pty=True)
+    ctx.run(f"{VENV_PREFIX} bandit -r -iii -lll --ini .bandit", pty=USE_PTY)
 
 
 @task(pre=[check_package, bandit], default=True)

--- a/tasks/style.py
+++ b/tasks/style.py
@@ -45,7 +45,7 @@ def pylint(ctx):
 
 @task(pre=[flake8, mypy, black_check, isort_check, commit_check], default=True)
 def run(ctx):
-    """Check style throguh linter (Note that pylint is not included)"""
+    """Check style through linter (Note that pylint is not included)"""
     pass
 
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1,12 +1,12 @@
 from invoke import task
 
-from tasks.common import VENV_PREFIX
+from tasks.common import USE_PTY, VENV_PREFIX
 
 
 @task(default=True)
 def run(ctx, allow_no_tests=False):
     """Run test cases"""
-    result = ctx.run(f"{VENV_PREFIX} pytest", pty=True, warn=True)
+    result = ctx.run(f"{VENV_PREFIX} pytest", pty=USE_PTY, warn=True)
     if allow_no_tests and result.exited == 5:
         exit(0)
     exit(result.exited)
@@ -15,4 +15,4 @@ def run(ctx, allow_no_tests=False):
 @task
 def cov(ctx):
     """Run test coverage check"""
-    ctx.run(f"{VENV_PREFIX} pytest --cov=vhcalc --cov-append tests/", pty=True)
+    ctx.run(f"{VENV_PREFIX} pytest --cov=vhcalc --cov-append tests/", pty=USE_PTY)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+  py39
+  py310
+  py311
+  py312
+skip_missing_interpreters = True
+
+[testenv]
+skip_install = true
+allowlist_externals = poetry
+commands_pre =
+    poetry install
+commands =
+    poetry run pytest tests/


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**
- **New feature**
  - support for multiple python interpreters: 3.9, 3.10, 3.11 and 3.12
  - integrated [tox](https://tox.wiki/en/4.18.0/#) for invokating multiple python interpreters in tests
  - update github actions for using matrix and targeting multiple python interpreters in tests
- **Refactoring**
  - invoke: typo on comment
  - invoke: fix deprecated poetry install without dev dependencies call
- **Breaking change** (any change that would cause existing functionality to not work as expected)
- **Documentation Update**
- **Other (please describe)**

## Description
<!--Describe what the change is**-->

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [x] Run `inv style` locally to ensure all linter checks pass
- [x] Run `inv test` locally to ensure all test cases pass
- [x] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
Closes #23 

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
