### PR TITLE
feat(app.py): default CLI group to a simpler entrypoint for generating images hashes from media filename input

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,18 +23,16 @@ It's a client-side library that implements a custom algorithm for extracting vid
 ## Usage
 
 ```sh
-$ export_imghash_from_media --help  
-Usage: export_imghash_from_media [OPTIONS]
-
-  This script exporting binary images hashes (fingerprints) from (any) media
-  (video file)
+$ vhcalc --help
+Usage: vhcalc [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --version                       Show the version and exit.
-  -r, --medias_pattern PATH-OR-GLOB
-                                  Pattern to find medias  [required]
-  -o, --output-file PATH          File where to write images hashes.
-  --help                          Show this message and exit.
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+imghash*                   extracting and exporting binary video hashes
+                           (fingerprints) from any video source
+export-imghash-from-media  extracting and exporting binary video hashes
+                           (fingerprints) from any video source
 ```
 
 
@@ -44,17 +42,15 @@ Docker hub: [yoyonel/vhcalc](https://hub.docker.com/r/yoyonel/vhcalc/)
 
 ```sh
 $ docker run -it yoyonel/vhcalc:main --help
-Usage: export_imghash_from_media [OPTIONS]
-
-  This script exporting binary images hashes (fingerprints) from (any) media
-  (video file)
+Usage: vhcalc [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --version                       Show the version and exit.
-  -r, --medias_pattern PATH-OR-GLOB
-                                  Pattern to find medias  [required]
-  -o, --output-file PATH          File where to write images hashes.
-  --help                          Show this message and exit.
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+imghash*                   extracting and exporting binary video hashes
+                           (fingerprints) from any video source
+export-imghash-from-media  extracting and exporting binary video hashes
+                           (fingerprints) from any video source
 ```
 
 ## Contributing

--- a/poetry.lock
+++ b/poetry.lock
@@ -2313,13 +2313,13 @@ test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "po
 
 [[package]]
 name = "setuptools"
-version = "74.0.0"
+version = "74.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-74.0.0-py3-none-any.whl", hash = "sha256:0274581a0037b638b9fc1c6883cc71c0210865aaa76073f7882376b641b84e8f"},
-    {file = "setuptools-74.0.0.tar.gz", hash = "sha256:a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"},
+    {file = "setuptools-74.1.1-py3-none-any.whl", hash = "sha256:fc91b5f89e392ef5b77fe143b17e32f65d3024744fba66dc3afe07201684d766"},
+    {file = "setuptools-74.1.1.tar.gz", hash = "sha256:2353af060c06388be1cecbf5953dcdb1f38362f87a2356c480b6b4d5fcfc8847"},
 ]
 
 [package.extras]
@@ -2521,41 +2521,41 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "watchdog"
-version = "5.0.0"
+version = "5.0.1"
 description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "watchdog-5.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf3216ec994eabb2212df9861f19056ca0d4cd3516d56cb95801933876519bfe"},
-    {file = "watchdog-5.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb59ad83a1700304fc1ac7bc53ae9e5cbe9d60a52ed9bba8e2e2d782a201bb2b"},
-    {file = "watchdog-5.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1228cb097e855d1798b550be8f0e9f0cfbac4384f9a3e91f66d250d03e11294e"},
-    {file = "watchdog-5.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3c177085c3d210d1c73cb4569442bdaef706ebebc423bd7aed9e90fc12b2e553"},
-    {file = "watchdog-5.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:01ab36cddc836a0f202c66267daaef92ba5c17c7d6436deff0587bb61234c5c9"},
-    {file = "watchdog-5.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0834c21efa3e767849b09e667274604c7cdfe30b49eb95d794565c53f4db3c1e"},
-    {file = "watchdog-5.0.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1e26f570dd7f5178656affb24d6f0e22ce66c8daf88d4061a27bfb9ac866b40d"},
-    {file = "watchdog-5.0.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d146331e6b206baa9f6dd40f72b5783ad2302c240df68e7fce196d30588ccf7b"},
-    {file = "watchdog-5.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6c96b1706430839872a3e33b9370ee3f7a0079f6b828129d88498ad1f96a0f45"},
-    {file = "watchdog-5.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:663b096368ed7831ac42259919fdb9e0a1f0a8994d972675dfbcca0225e74de1"},
-    {file = "watchdog-5.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:685931412978d00a91a193d9018fc9e394e565e8e7a0c275512a80e59c6e85f8"},
-    {file = "watchdog-5.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:109daafc5b0f2a98d1fa9475ff9737eb3559d57b18129a36495e20c71de0b44f"},
-    {file = "watchdog-5.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c2b4d90962639ae7cee371ea3a8da506831945d4418eee090c53bc38e6648dc6"},
-    {file = "watchdog-5.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6e58eafe9cc5ceebe1562cdb89bacdcd0ef470896e8b0139fe677a5abec243da"},
-    {file = "watchdog-5.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b8d747bf6d8fe5ce89cb1a36c3724d1599bd4cde3f90fcba518e6260c7058a52"},
-    {file = "watchdog-5.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:bc16d448a74a929b896ed9578c25756b2125400b19b3258be8d9a681c7ae8e71"},
-    {file = "watchdog-5.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:7e6b0e9b8a9dc3865d65888b5f5222da4ba9c4e09eab13cff5e305e7b7e7248f"},
-    {file = "watchdog-5.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:4fe6780915000743074236b21b6c37419aea71112af62237881bc265589fe463"},
-    {file = "watchdog-5.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:0710e9502727f688a7e06d48078545c54485b3d6eb53b171810879d8223c362a"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d76efab5248aafbf8a2c2a63cd7b9545e6b346ad1397af8b862a3bb3140787d8"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:ff4e957c45c446de34c513eadce01d0b65da7eee47c01dce472dd136124552c9"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:16c1aa3377bb1f82c5e24277fcbf4e2cac3c4ce46aaaf7212d53caa9076eb7b7"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:22fcad6168fc43cf0e709bd854be5b8edbb0b260f0a6f28f1ea9baa53c6907f7"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:0120b2fa65732797ffa65fa8ee5540c288aa861d91447df298626d6385a24658"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2aa59fab7ff75281778c649557275ca3085eccbdf825a0e2a5ca3810e977afe5"},
-    {file = "watchdog-5.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:78db0fe0336958fc0e1269545c980b6f33d04d184ba191b2800a8b71d3e971a9"},
-    {file = "watchdog-5.0.0-py3-none-win32.whl", hash = "sha256:d1acef802916083f2ad7988efc7decf07e46e266916c0a09d8fb9d387288ea12"},
-    {file = "watchdog-5.0.0-py3-none-win_amd64.whl", hash = "sha256:3c2d50fdb86aa6df3973313272f5a17eb26eab29ff5a0bf54b6d34597b4dc4e4"},
-    {file = "watchdog-5.0.0-py3-none-win_ia64.whl", hash = "sha256:1d17ec7e022c34fa7ddc72aa41bf28c9d1207ffb193df18ba4f6fde453725b3c"},
-    {file = "watchdog-5.0.0.tar.gz", hash = "sha256:990aedb9e2f336b45a70aed9c014450e7c4a70fd99c5f5b1834d57e1453a177e"},
+    {file = "watchdog-5.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a6b8c6c82ada78479a0df568d27d69aa07105aba9301ac66d1ae162645f4ba34"},
+    {file = "watchdog-5.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1e8ca9b7f5f03d2f0556a43db1e9adf1e5af6adf52e0890f781324514b67a612"},
+    {file = "watchdog-5.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c92812a358eabebe92b12b9290d16dc95c8003654658f6b2676c9a2103a73ceb"},
+    {file = "watchdog-5.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a03a6ccb846ead406a25a0b702d0a6b88fdfa77becaf907cfcfce7737ebbda1f"},
+    {file = "watchdog-5.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:39f0de161a822402f0f00c68b82349a4d71c9814e749148ca2b083a25606dbf9"},
+    {file = "watchdog-5.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5541a8765c4090decb4dba55d3dceb57724748a717ceaba8dc4f213edb0026e0"},
+    {file = "watchdog-5.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e321f1561adea30e447130882efe451af519646178d04189d6ba91a8cd7d88a5"},
+    {file = "watchdog-5.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c4ae0b3e95455fa9d959aa3b253c87845ad454ef188a4bf5a69cab287c131216"},
+    {file = "watchdog-5.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b2d56425dfa0c1e6f8a510f21d3d54ef7fe50bbc29638943c2cb1394b7b49156"},
+    {file = "watchdog-5.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:70e30116849f4ec52240eb1fad83d27e525eae179bfe1c09b3bf120163d731b6"},
+    {file = "watchdog-5.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f66df2c152edf5a2fe472bb2f8a5d562165bcf6cf9686cee5d75e524c21ca895"},
+    {file = "watchdog-5.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6bb68d9adb9c45f0dc1c2b12f4fb6eab0463a8f9741e371e4ede6769064e0785"},
+    {file = "watchdog-5.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6fbb4dd5ace074a2969825fde10034b35b31efcb6973defb22eb945b1d3acc37"},
+    {file = "watchdog-5.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:753c6a4c1eea9d3b96cd58159b49103e66cb288216a414ab9ad234ccc7642ec2"},
+    {file = "watchdog-5.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:20a28c8b0b3edf4ea2b27fb3527fc0a348e983f22a4317d316bb561524391932"},
+    {file = "watchdog-5.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a1cd7c919940b15f253db8279a579fb81e4e4e434b39b11a1cb7f54fe3fa46a6"},
+    {file = "watchdog-5.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:a791dfc050ed24b82f7f100ae794192594fe863a7e9bdafcdfa5c6e405a981e5"},
+    {file = "watchdog-5.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:8ba1472b5fa7c644e49641f70d7ccc567f70b54d776defa5d6f755dc2edc3fbb"},
+    {file = "watchdog-5.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:b21e6601efe8453514c2fc21aca57fb5413c3d8b157bfe520b05b57b1788a167"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:763c6f82bb65504b47d4aea268462b2fb662676676356e04787f332a11f03eb0"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_armv7l.whl", hash = "sha256:664917cd513538728875a42d5654584b533da88cf06680452c98e73b45466968"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_i686.whl", hash = "sha256:39e828c4270452b966bc9d814911a3c7e24c62d726d2a3245f5841664ff56b5e"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_ppc64.whl", hash = "sha256:59ec6111f3750772badae3403ef17263489ed6f27ac01ec50c0244b2afa258fb"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:f3006361dba2005552cc8aa49c44d16a10e0a1939bb3286e888a14f722122808"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:72dbdffe4aa0c36c59f4a5190bceeb7fdfdf849ab98a562b3a783a64cc6dacdd"},
+    {file = "watchdog-5.0.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c93aa24899cb4e8a51492c7ccc420bea45ced502fe9ef2e83f9ab1107e5a13b5"},
+    {file = "watchdog-5.0.1-py3-none-win32.whl", hash = "sha256:2b8cd627b76194e725ed6f48d9524b1ad93a51a0dc3bd0225c56023716245091"},
+    {file = "watchdog-5.0.1-py3-none-win_amd64.whl", hash = "sha256:4eaebff2f938f5325788cef26521891b2d8ecc8e7852aa123a9b458815f93875"},
+    {file = "watchdog-5.0.1-py3-none-win_ia64.whl", hash = "sha256:9b1b32f89f95162f09aea6e15d9384f6e0490152f10d7ed241f8a85cddc50658"},
+    {file = "watchdog-5.0.1.tar.gz", hash = "sha256:f0180e84e6493ef7c82e051334e8c9b00ffd89fa9de5e0613d3c267f6ccf2d38"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,8 @@ norecursedirs = [
         'venv/*',
         '*/virtualenv/*',
         '*/virtualenvs/*',
-        '*/tests/*'
+        '*/tests/*',
+        '*/tools/click_default_group.py'
     ]
     [tool.coverage.run]
     relative_files = true
@@ -132,20 +133,25 @@ repository = "https://github.com/yoyonel/vhcalc"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-loguru = "^0.7.2"
-Distance = "^0.1.3"
-numpy = "^2.0.2"
-bitstring = "^4.2.3"
-ImageHash = "^4.3.1"
-imageio-ffmpeg = "^0.5.1"
-colorama = "^0.4.6"
+
+# CLI
 click = "^8.1.7"
 click-pathlib = "^2020.3.13"
-#click-path = "0.0.5"   # '[IndexError] list index out of range' on poetry install
-typeguard = "^4.3.0"
 rich = "^13.8.0"
 rich-click = "^1.8.3"
+#click-path = "0.0.5"   # '[IndexError] list index out of range' on poetry install
+typeguard = "^4.3.0"
+loguru = "^0.7.2"
+colorama = "^0.4.6"
+
+# Processing
+numpy = "^2.0.2"
+Distance = "^0.1.3"
+bitstring = "^4.2.3"
+ImageHash = "^4.3.1"
 Pillow = ">=9.1.1"
+imageio-ffmpeg = "^0.5.1"
+
 types-setuptools = "^74.0.0.20240830"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,6 +124,9 @@ bitarray==2.9.2 ; python_version >= "3.9" and python_version < "4.0" \
 bitstring==4.2.3 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:20ed0036e2fcf0323acb0f92f0b7b178516a080f3e91061470aa019ac4ede404 \
     --hash=sha256:e0c447af3fda0d114f77b88c2d199f02f97ee7e957e6d719f40f41cf15fbb897
+click-default-group==1.2.4 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:9b60486923720e7fc61731bdb32b617039aba820e22e1c88766b1125592eaa5f \
+    --hash=sha256:eb3f3c99ec0d456ca6cd2a7f08f7d4e91771bef51b01bdd9580cc6450fe1251e
 click-pathlib==2020.3.13.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:37faab20677ce754176378cd9be82fd9e7e28b5d5fa4f1cc89613cb6b9fe9d97 \
     --hash=sha256:e74a7a209699107d6aa884b3070e1f81e67dea10acf2244fbd3a4eafad207c1c
@@ -353,9 +356,9 @@ scipy==1.13.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299 \
     --hash=sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94 \
     --hash=sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f
-setuptools==74.0.0 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:0274581a0037b638b9fc1c6883cc71c0210865aaa76073f7882376b641b84e8f \
-    --hash=sha256:a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e
+setuptools==74.1.0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:bea195a800f510ba3a2bc65645c88b7e016fe36709fefc58a880c4ae8a0138d7 \
+    --hash=sha256:cee604bd76cc092355a4e43ec17aee5369095974f41f088676724dc6bc2c9ef8
 typeguard==4.3.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:4d24c5b39a117f8a895b9da7a9b3114f04eb63bade45a4492de49b175b6f7dfa \
     --hash=sha256:92ee6a0aec9135181eae6067ebd617fd9de8d75d714fb548728a4933b1dea651

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ exclude =
     dist,
     .tox
 max-line-length = 88
+per-file-ignores =
+    # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#e701-e704
+    vhcalc/tools/click_default_group.py:W503,A001,E704

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -92,3 +92,30 @@ def test_cli_version(cli_runner):
     app_name_expected = "vhcalc"
     version_expected = version("vhcalc")
     assert f"{app_name_expected}, version {version_expected}\n" in result.output
+
+
+def test_cli_imghash(big_buck_bunny_trailer, cli_runner, tmpdir):
+    p_video = big_buck_bunny_trailer
+    resource_video_name = p_video.stem
+
+    binary_img_hash_file = tmpdir.mkdir("phash") / f"{resource_video_name}.phash"
+
+    result = cli_runner.invoke(
+        cli,
+        args=f"{str(p_video)} {binary_img_hash_file}",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert not result.output
+
+    _reader, metadata = build_reader_frames(p_video)
+    expected_size_binary_file = metadata.nb_frames * 8
+    assert Path(binary_img_hash_file).stat().st_size == expected_size_binary_file
+
+
+def test_cli_imghash_without_export_file(big_buck_bunny_trailer, cli_runner):
+    p_video = big_buck_bunny_trailer
+
+    result = cli_runner.invoke(cli, args=str(p_video), catch_exceptions=False)
+    assert result.exit_code == 0
+    # TODO: catch stdout with binary images hashes

--- a/vhcalc/services/__init__.py
+++ b/vhcalc/services/__init__.py
@@ -1,5 +1,6 @@
-from .imghashes import export_imghash_from_media
+from .imghashes import compute_imghash_from_media, export_imghash_from_media
 
 __all__ = [
     "export_imghash_from_media",
+    "compute_imghash_from_media",
 ]

--- a/vhcalc/tools/click_default_group.py
+++ b/vhcalc/tools/click_default_group.py
@@ -1,0 +1,168 @@
+"""
+   click_default_group
+   ~~~~~~~~~~~~~~~~~~~
+
+   Define a default subcommand by `default=True`:
+
+   .. sourcecode:: python
+
+      import click
+      from click_default_group import DefaultGroup
+
+      @click.group(cls=DefaultGroup, default_if_no_args=True)
+      def cli():
+          pass
+
+      @cli.command(default=True)
+      def foo():
+          click.echo('foo')
+
+      @cli.command()
+      def bar():
+          click.echo('bar')
+
+   Then you can invoke that without explicit subcommand name:
+
+   .. sourcecode:: console
+
+      $ cli.py --help
+      Usage: cli.py [OPTIONS] COMMAND [ARGS]...
+
+      Options:
+        --help    Show this message and exit.
+
+      Command:
+        foo*
+        bar
+
+      $ cli.py
+      foo
+      $ cli.py foo
+      foo
+      $ cli.py bar
+      bar
+
+"""
+
+import typing as t
+import warnings
+
+import click
+
+__all__ = ["DefaultGroup"]
+__version__ = "1.2.4"
+
+
+class DefaultGroup(click.Group):
+    """Invokes a subcommand marked with `default=True` if any subcommand not
+    chosen.
+
+    :param default_if_no_args: resolves to the default command if no arguments
+                               passed.
+
+    """
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        # To resolve as the default command.
+        if not kwargs.get("ignore_unknown_options", True):
+            raise ValueError("Default group accepts unknown options")
+        self.ignore_unknown_options = True
+        self.default_cmd_name = kwargs.pop("default", None)
+        self.default_if_no_args = kwargs.pop("default_if_no_args", False)
+        super().__init__(*args, **kwargs)
+
+    def set_default_command(self, command: t.Any) -> None:
+        """Sets a command function as the default command."""
+        cmd_name = command.name
+        self.add_command(command)
+        self.default_cmd_name = cmd_name
+
+    def parse_args(self, ctx: click.core.Context, args: t.List[str]) -> t.List[str]:
+        if not args and self.default_if_no_args:
+            args.insert(0, self.default_cmd_name)
+        return super().parse_args(ctx, args)
+
+    def get_command(
+        self, ctx: click.core.Context, cmd_name: str
+    ) -> t.Optional[click.core.Command]:
+        if cmd_name not in self.commands:
+            # No command name matched.
+            ctx.arg0 = cmd_name  # type: ignore
+            cmd_name = self.default_cmd_name
+        return super().get_command(ctx, cmd_name)
+
+    def resolve_command(
+        self, ctx: click.core.Context, args: t.List[str]
+    ) -> t.Tuple[t.Optional[str], t.Optional[click.core.Command], t.List[str]]:
+        cmd_name, cmd, args = super().resolve_command(ctx, args)
+        if cmd and hasattr(ctx, "arg0"):
+            args.insert(0, ctx.arg0)
+            cmd_name = cmd.name
+        return cmd_name, cmd, args
+
+    def format_commands(
+        self, ctx: click.core.Context, formatter: click.formatting.HelpFormatter
+    ) -> None:
+        new_formatter = DefaultCommandFormatter(self, formatter, mark="*")
+        return super().format_commands(ctx, new_formatter)
+
+    @t.overload
+    def command(self, __func: t.Callable[..., t.Any]) -> click.core.Command: ...
+
+    @t.overload
+    def command(
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Callable[[t.Callable[..., t.Any]], click.core.Command]: ...
+
+    def command(
+        self, *args: t.Any, **kwargs: t.Any
+    ) -> t.Union[
+        t.Callable[[t.Callable[..., t.Any]], click.core.Command], click.core.Command
+    ]:
+        default = kwargs.pop("default", False)
+        decorator: t.Callable[[t.Callable[..., t.Any]], click.core.Command] = (
+            super().command(*args, **kwargs)
+        )
+        if not default:
+            return decorator
+        warnings.warn(
+            "Use default param of DefaultGroup or set_default_command() instead",
+            DeprecationWarning,
+        )
+
+        def _decorator(f: t.Callable[..., t.Any]) -> click.core.Command:
+            cmd: click.core.Command = decorator(f)
+            self.set_default_command(cmd)
+            return cmd
+
+        return _decorator
+
+
+class DefaultCommandFormatter(click.formatting.HelpFormatter):
+    """Wraps a formatter to mark a default command."""
+
+    def __init__(
+        self,
+        group: DefaultGroup,
+        formatter: click.formatting.HelpFormatter,
+        mark: str = "*",
+    ):
+        self.group = group
+        self.formatter = formatter
+        self.mark = mark
+
+        super().__init__()
+
+    def __getattr__(self, attr: str) -> t.Any:
+        return getattr(self.formatter, attr)
+
+    def write_dl(
+        self, rows: t.Sequence[t.Tuple[str, str]], *args: t.Any, **kwargs: t.Any
+    ) -> None:
+        rows_: t.List[t.Tuple[str, str]] = []
+        for cmd_name, text in rows:
+            if cmd_name == self.group.default_cmd_name:
+                rows_.insert(0, (cmd_name + self.mark, text))
+            else:
+                rows_.append((cmd_name, text))
+        return self.formatter.write_dl(rows_, *args, **kwargs)


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

```shell
╰─ vhcalc --help
Usage: vhcalc [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.
imghash*                   extracting and exporting binary video hashes
                           (fingerprints) from any video source
export-imghash-from-media  extracting and exporting binary video hashes
                           (fingerprints) from any video source
```

new entrypoint by default:
```shell
╰─ vhcalc ~/Vidéos/__PERSO__/Facebook.mp4 | md5sum
The frame size for reading (32, 32) is different from the source frame size (1280, 720).
c845d3eeb1cf740b9fd637df045b5664  -
```

previous entrypoint (no changes):
```shell
╰─ vhcalc export-imghash-from-media -r ~/Vidéos/__PERSO__/Facebook.mp4 && cat /tmp/Facebook.mp4.29.98fps.phash | md5sum
The frame size for reading (32, 32) is different from the source frame size (1280, 720).
MetaData(fps=29.98, duration=46.25, nb_frames=1384)
Number of frames to read: 1384
Chunk size (nb frames): 449
output_file: /tmp/Facebook.mp4.29.98fps.phash
Facebook.mp4 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100.0% • 14.4/11.1 kB • 10.6 kB/s • 0:00:01/0:00:00
c845d3eeb1cf740b9fd637df045b5664  -
```

- **Bugfix**
- **New feature**
- **Refactoring**
- **Breaking change** (any change that would cause existing functionality to not work as expected)
- **Documentation Update**
- **Other (please describe)**

## Description
<!--Describe what the change is**-->

## Checklist:
- [x] Add test cases to all the changes you introduce
- [x] Run `inv style` locally to ensure all linter checks pass
- [x] Run `inv test` locally to ensure all test cases pass
- [x] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
